### PR TITLE
Fix lint CI: migrate ruff suppressions from noqa to ruff: ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,21 +142,21 @@ select = [
 ]
 
 ignore = [
-    "N803",      # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-argument-name/)
-    "N806",      # [pep8-naming](https://docs.astral.sh/ruff/rules/non-lowercase-variable-in-function/)
-    "PLR2004",   # [pylint](https://docs.astral.sh/ruff/rules/magic-value-comparison/)
-    "S311",      # [flake8-bandit](https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/)
+    "invalid-argument-name",      # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-argument-name/)
+    "non-lowercase-variable-in-function",      # [pep8-naming](https://docs.astral.sh/ruff/rules/non-lowercase-variable-in-function/)
+    "magic-value-comparison",   # [pylint](https://docs.astral.sh/ruff/rules/magic-value-comparison/)
+    "suspicious-non-cryptographic-random-usage",      # [flake8-bandit](https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/)
 ]
 
 
 # Ignore strict naming rules for soerp scientific code, but keep them for other modules.
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
-    "ANN001",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-type-function-argument/)
-    "ANN201",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/)
-    "ANN202",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-private-function/)
-    "S101",       # [flake8-bandit](https://docs.astral.sh/ruff/rules/assert/)
-    "PLR6301",    # [pylint](https://docs.astral.sh/ruff/rules/no-self-use/)
+    "missing-type-function-argument",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-type-function-argument/)
+    "missing-return-type-undocumented-public-function",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/)
+    "missing-return-type-private-function",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-private-function/)
+    "assert",       # [flake8-bandit](https://docs.astral.sh/ruff/rules/assert/)
+    "no-self-use",    # [pylint](https://docs.astral.sh/ruff/rules/no-self-use/)
 ]
 
 [tool.ruff.format]

--- a/soerp/__init__.py
+++ b/soerp/__init__.py
@@ -58,7 +58,7 @@ from .uncertain_variable import UncertainVariable, uv
 
 __author__ = "Abraham Lee"
 
-try:  # noqa: RUF067, RUF100
+try:  # ruff: ignore[non-empty-init-module]
     __version__ = version(__name__)
 except PackageNotFoundError:
     __version__ = "unknown"

--- a/soerp/method_of_moments.py
+++ b/soerp/method_of_moments.py
@@ -128,7 +128,7 @@ def standardize(
 ###############################################################################
 
 
-def rawmoment(  # noqa: PLR0912, PLR0915
+def rawmoment(  # ruff: ignore[too-many-branches, too-many-statements]
     slc: NDArray, sqc: NDArray, scp: NDArray, vm: NDArray, k: int
 ) -> float:
     """
@@ -177,7 +177,7 @@ def rawmoment(  # noqa: PLR0912, PLR0915
     ############################
     # The 0th raw moment
 
-    if k == 0:  # noqa: PLR1702
+    if k == 0:  # ruff: ignore[too-many-nested-blocks]
         ans = 1
 
     ############################
@@ -873,7 +873,7 @@ def variance_contrib(
 ###############################################################################
 
 
-def soerp_numeric(  # noqa: PLR0912, PLR0913, PLR0917
+def soerp_numeric(  # ruff: ignore[too-many-branches, too-many-arguments, too-many-positional-arguments]
     slc: NDArray,
     sqc: NDArray,
     scp: NDArray,
@@ -962,7 +962,7 @@ def soerp_numeric(  # noqa: PLR0912, PLR0913, PLR0917
         FOURTH CENTRAL MOMENT (MU4DL).............  3.8956371E+12
         COEFFICIENT OF KURTOSIS (BETA2)...........  4.1121529E+00
         ********************************************************************************
-    """  # noqa: E501
+    """  # ruff: ignore[line-too-long]
     if not silent:
         print("\n", "*" * 80)
         if title:
@@ -1007,7 +1007,7 @@ def soerp_numeric(  # noqa: PLR0912, PLR0913, PLR0917
         for i in range(n - 1):
             for j in range(i + 1, n):
                 print(
-                    f"Variance Contribution of cp[x{i:d}, x{j:d}]: {vcp[i, j]:7.5%}"  # noqa: E501
+                    f"Variance Contribution of cp[x{i:d}, x{j:d}]: {vcp[i, j]:7.5%}"  # ruff: ignore[line-too-long]
                 )
 
     ############################

--- a/soerp/umath.py
+++ b/soerp/umath.py
@@ -48,7 +48,7 @@ def _uf_unary(
     return hx
 
 
-def _uf_binary(  # noqa: PLR0913, PLR0917
+def _uf_binary(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     x: UncertainFunction | float,
     y: UncertainFunction | float,
     hx: float,
@@ -195,7 +195,7 @@ def atan2(
     # $\partial/\partial y = x/r^2$, $\partial/\partial x = -y/r^2$
     dh_dy = xv / r2
     dh_dx = -yv / r2
-    # $\partial^2/\partial y^2 = -2xy/r^4$,  $\partial^2/\partial x^2 = 2xy/r^4$,  $\partial^2/(\partial x \partial y) = (y^2-x^2)/r^4$ # noqa: E501
+    # $\partial^2/\partial y^2 = -2xy/r^4$,  $\partial^2/\partial x^2 = 2xy/r^4$,  $\partial^2/(\partial x \partial y) = (y^2-x^2)/r^4$ # ruff: ignore[line-too-long]
     d2h_dy2 = -2.0 * xv * yv / (r2 * r2)
     d2h_dx2 = 2.0 * xv * yv / (r2 * r2)
     d2h_dxy = (yv * yv - xv * xv) / (r2 * r2)
@@ -212,7 +212,7 @@ def acot(x: UncertainFunction | float) -> UncertainFunction | float:
     -------
     result : UncertainFunction | float
         acot(x) with uncertainty propagated.
-    """  # noqa: E501
+    """  # ruff: ignore[line-too-long]
     fx = x.x if isinstance(x, UncertainFunction) else x
     q = 1.0 + fx * fx
     d1 = -1.0 / q
@@ -690,7 +690,7 @@ def gamma(x: UncertainFunction | float) -> UncertainFunction | float:
     -------
     result : UncertainFunction | float
         $\Gamma(x)$ with uncertainty propagated.
-    """  # noqa: E501
+    """  # ruff: ignore[line-too-long]
     fx = x.x if isinstance(x, UncertainFunction) else x
     gx = math.gamma(fx)
     psi = float(digamma(fx))

--- a/soerp/uncertain_function.py
+++ b/soerp/uncertain_function.py
@@ -44,9 +44,9 @@ def to_uncertain_func(
 #
 # Each UncertainFunction stores:
 #   x    - function value
-#   _lc  - {var: $\partial f/\partial \text{var}$}              first-order partials                        # noqa: E501
-#   _qc  - {var: $\partial^2 f/\partial \text{var}^2$}            pure second-order partials                  # noqa: E501
-#   _cp  - {(var_i, var_j): $\partial^2 f/(\partial \text{var}_i \partial \text{var}_j)$}  cross second-order partials (i < j)   # noqa: E501
+#   _lc  - {var: $\partial f/\partial \text{var}$}              first-order partials                        # ruff: ignore[line-too-long]
+#   _qc  - {var: $\partial^2 f/\partial \text{var}^2$}            pure second-order partials                  # ruff: ignore[line-too-long]
+#   _cp  - {(var_i, var_j): $\partial^2 f/(\partial \text{var}_i \partial \text{var}_j)$}  cross second-order partials (i < j)   # ruff: ignore[line-too-long]
 #
 # The chain rules implemented here are exact for polynomial functions and give
 # the second-order Taylor approximation for non-polynomial ones, which is
@@ -54,7 +54,7 @@ def to_uncertain_func(
 ###############################################################################
 
 
-def _combine_op(  # noqa: PLR0913, PLR0914, PLR0917
+def _combine_op(  # ruff: ignore[too-many-arguments, too-many-locals, too-many-positional-arguments]
     f: "UncertainFunction",
     g: "UncertainFunction",
     hx: float,
@@ -179,7 +179,7 @@ def _unary_op(
 ###############################################################################
 
 
-class UncertainFunction:  # noqa: PLR0904
+class UncertainFunction:  # ruff: ignore[too-many-public-methods]
     """
     UncertainFunction objects represent the uncertainty of a result of
     calculations with uncertain variables. Nearly all basic mathematical
@@ -202,7 +202,7 @@ class UncertainFunction:  # noqa: PLR0904
         lc : dict   - {var: $\partial f/\partial \text{var}$}          first-order partials
         qc : dict   - {var: $\partial^2 f/\partial \text{var}^2$}         pure second-order partials
         cp : dict   - {(var_i, var_j): $\partial^2 f/(\partial \text{var}_i \partial \text{var}_j)$}   cross partials  (i < j ordering)
-        """  # noqa: E501
+        """  # ruff: ignore[line-too-long]
         self.x = float(x)
         self._lc = lc if lc is not None else {}
         self._qc = qc if qc is not None else {}
@@ -222,7 +222,7 @@ class UncertainFunction:  # noqa: PLR0904
         -------
         derivative : dict or float
             First-derivative dict if var is None, else scalar $\partial f/\partial \text{var}$.
-        """  # noqa: E501
+        """  # ruff: ignore[line-too-long]
         if var is None:
             return self._lc
         return self._lc.get(var, 0.0)
@@ -234,7 +234,7 @@ class UncertainFunction:  # noqa: PLR0904
         -------
         derivative : dict or float
             Pure second-derivative dict if var is None, else $\partial^2 f/\partial \text{var}^2$.
-        """  # noqa: E501
+        """  # ruff: ignore[line-too-long]
         if var is None:
             return self._qc
         return self._qc.get(var, 0.0)
@@ -250,7 +250,7 @@ class UncertainFunction:  # noqa: PLR0904
         -------
         derivative : dict or float
             Cross-derivative dict if var1 is None, else $\partial^2 f/(\partial \text{var}_1 \partial \text{var}_2)$.
-        """  # noqa: E501
+        """  # ruff: ignore[line-too-long]
         if var1 is None:
             return self._cp
         return self._cp.get((var1, var2), self._cp.get((var2, var1), 0.0))
@@ -447,7 +447,7 @@ class UncertainFunction:  # noqa: PLR0904
 
         return (slc, sqc, scp, var_moments, f0)
 
-    def error_components(  # noqa: PLR0912, PLR0914, PLR0915
+    def error_components(  # ruff: ignore[too-many-branches, too-many-locals, too-many-statements]
         self, *, pprint: bool = False, as_eq_terms: bool = False
     ) -> "dict | tuple | None":
         """

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -10,7 +10,7 @@ from soerp import N, uv
 
 class TestADCorrectness:
     def test_linear_mean_and_var(self):
-        # z = a*x + b*y  →  var(z) = $a^2 \cdot \text{var}(x) + b^2 \cdot \text{var}(y)$ for independent x, y  # noqa: E501
+        # z = a*x + b*y  →  var(z) = $a^2 \cdot \text{var}(x) + b^2 \cdot \text{var}(y)$ for independent x, y  # ruff: ignore[line-too-long]
         x = uv([2.0, 1.0, 0, 3, 0, 15, 0, 105])
         y = uv([3.0, 4.0, 0, 3, 0, 15, 0, 105])
         z = 2 * x + 3 * y

--- a/tests/test_truss.py
+++ b/tests/test_truss.py
@@ -23,7 +23,7 @@ class TestTwoBarTruss:
         P = cls(66, 1.0, tag="P")
         return H, B, d, t, E, rho, P
 
-    def _compute(self, H, B, d, t, E, rho, P):  # noqa: PLR0913, PLR0917
+    def _compute(self, H, B, d, t, E, rho, P):  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
         pi = self.pi
         wght = 2 * pi * rho * d * t * umath.sqrt((B / 2) ** 2 + H**2)
         strs = (P * umath.sqrt((B / 2) ** 2 + H**2)) / (2 * pi * d * t * H)
@@ -31,7 +31,7 @@ class TestTwoBarTruss:
         defl = (P * ((B / 2) ** 2 + H**2) ** 1.5) / (2 * pi * d * t * H**2 * E)
         return wght, strs, buck, defl
 
-    def test_means_match_deterministic(self):  # noqa: PLR0914
+    def test_means_match_deterministic(self):  # ruff: ignore[too-many-locals]
         H, B, d, t, E, rho, P = self._build(N)
         wght, strs, buck, defl = self._compute(H, B, d, t, E, rho, P)
 

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -39,7 +39,7 @@ class TestUmath:
 
     def test_exp_uncertain(self):
         # E[exp(X)] for X~N(0, sigma) includes the second-order correction:
-        # E[exp(X)] ≈ $\exp(\mu) \cdot (1 + \sigma^2/2) = \exp(0) \cdot (1 + 0.01/2) = 1.005$  # noqa: E501
+        # E[exp(X)] ≈ $\exp(\mu) \cdot (1 + \sigma^2/2) = \exp(0) \cdot (1 + 0.01/2) = 1.005$  # ruff: ignore[line-too-long]
         x = N(0.0, 0.1)
         r = umath.exp(x)
         assert r.mean == pytest.approx(1.005, rel=1e-3)


### PR DESCRIPTION
## Lint

ruff 0.16 added three preview rules. These configs set `preview = true` and
use an unpinned `astral-sh/ruff-action@v3`, so CI went red with no change on
our side:

| Rule | Migration |
| --- | --- |
| `RUF105` noqa-comments | `# noqa: X` → `# ruff: ignore[X]` |
| `RUF106` rule-codes-in-suppression-comments | code → readable name |
| `RUF201` rule-codes-in-selectors | same, for `per-file-ignores` |

Suppressions now name the rule they silence, e.g.
`# noqa: PLW3201` → `# ruff: ignore[bad-dunder-method-name]`.

Fixes were scoped to exactly these three rules rather than a blanket
`--fix`: ruff's autofix mangles malformed input, turning `# noqa RUF067`
(missing colon) into `# ruff: ignore[...] RUF067` with stray trailing text.
Comments and config selectors only — no behavioural change.

## Verification

`ruff check` and `ruff format --diff` both pass using this workflow's own
command, and the test suite passes locally via uv.

Not verified: the macOS steps could not be exercised locally (no macOS
runner). Worth watching the first CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
