### PR TITLE
style: use a generator inside max() in the sync script

### DIFF
--- a/.github/scripts/sync_python_versions.py
+++ b/.github/scripts/sync_python_versions.py
@@ -244,7 +244,7 @@ def resolve(project: Table, active: list[str]) -> Resolved:
     requires = str(project.get("requires-python", "")).strip()
     match = FLOOR.search(requires)
     was_floor = match.group(1) if match else None
-    floor = max([f for f in (was_floor, active[0]) if f], key=key)
+    floor = max((f for f in (was_floor, active[0]) if f), key=key)
     supported = [v for v in active if key(v) >= key(floor)]
     if not supported:
         fail(f"floor {was_floor} excludes every active version")


### PR DESCRIPTION
One-line follow-up so every copy of `sync_python_versions.py` stays byte-identical across the org.

Codacy (enabled on `sdepack`) flags the list comprehension inside `max()` as `R1728` *consider-using-generator*. Building a throwaway list only to take its maximum allocates for nothing, and the generator is equivalent here because `active[0]` is always present, so the argument is never empty.

```diff
-    floor = max([f for f in (was_floor, active[0]) if f], key=key)
+    floor = max((f for f in (was_floor, active[0]) if f), key=key)
```

Codacy only gates `sdepack`, but the script is meant to be one canonical file, so this lands everywhere to prevent drift.

Verified: pylint 0, pydocstyle 0, ruff lint and `format --check` 0 against the repo configs, behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)