### PR TITLE
chore: exclude .github from static analysis

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,9 @@
+# Codacy analysis scope.
+#
+# CI workflow definitions and the helper scripts they run are never
+# shipped in the published package, so findings there fail the quality
+# gate without describing any risk to users of this project. This
+# mirrors the scope already set for SonarQube Cloud in
+# .sonarcloud.properties.
+exclude_paths:
+  - ".github/**"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ local_scheme = "no-local-version"
 enable = ["cpython-prerelease"]
 
 [tool.ruff]
+# CI workflow definitions and the helper scripts they run are not
+# part of the published package, so they are out of scope here.
+extend-exclude = [".github"]
 line-length = 80
 indent-width = 4
 preview = true


### PR DESCRIPTION
Codacy, SonarQube Cloud and ruff all reach into `.github`, so CI workflow definitions and the helper scripts they run get graded as if they were library code. Nothing under `.github` ships in the published package, so findings there fail a quality gate without describing any risk to users of this project.

- Adds `.codacy.yml` excluding `.github/**`, matching the scope already set for SonarQube Cloud in `.sonarcloud.properties` and following the pattern already used in `permit`.
- Points ruff away from the same directory via `extend-exclude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)