### PR TITLE
chore(docs): use absolute asset URLs and project icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![SOERP](docs/assets/soerp-banner.png)
+![SOERP](https://raw.githubusercontent.com/eggzec/soerp/master/docs/assets/soerp-banner.png)
 
 # SOERP
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-![SOERP](assets/soerp-banner.png)
+![SOERP](https://raw.githubusercontent.com/eggzec/soerp/master/docs/assets/soerp-banner.png)
 
 # SOERP
 
-![SOERP logo](assets/SOERP.svg){ width="100" }
+![SOERP logo](https://raw.githubusercontent.com/eggzec/soerp/master/docs/assets/soerp-icon.svg){ width="120" }
 
 **Second Order Error Propagation for Python**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ extra:
 
 theme:
   name: material
-  favicon: assets/favicon.svg
-  logo: assets/favicon.svg
+  favicon: assets/soerp-icon.png
+  logo: assets/soerp-icon.svg
   features:
     - content.code.copy
 


### PR DESCRIPTION
Points README and docs image references at `raw.githubusercontent.com` absolute URLs so banners render on GitHub and PyPI instead of breaking on relative paths, and sets the MkDocs/Zensical theme `logo` and `favicon` to the current project icon (replacing stale or missing entries).

Verified: every config still parses and all referenced icon files exist on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)