### PR TITLE
Check dependencies monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
 
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"


### PR DESCRIPTION
## Summary

Sets every `schedule.interval` in `.github/dependabot.yml` to `monthly`.

`schedule.day` is dropped wherever it appeared: that key only applies when the interval is `weekly`, so leaving it alongside `monthly` would be a dead setting that reads as if it still controls timing.

## Test plan

Config parses as valid YAML; `version: 2` intact; every entry under `updates` now reads `interval: monthly` with no leftover `day` key. Ecosystem, directory, grouping, labels and commit-message settings are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)